### PR TITLE
Fixed space followed by uppercase to be a single dash.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ dashify('foo barBaz');
 //=> 'foo-bar-baz'
 dashify('foo barBaz quux');
 //=> 'foo-bar-baz-quux'
+dashify('foo BarBaz quux');
+//=> 'foo-bar-baz-quux'
 ```
 
 ## Related projects

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = function dashify(str) {
   if (typeof str !== 'string') {
     throw new TypeError('dashify expects a string.');
   }
-  str = str.replace(/[A-Z]/g, '-$&');
+  str = str.replace(/([a-z])([A-Z])/g, '$1-$2');
   str = str.replace(/[ \t\W]/g, '-');
   str = str.replace(/^\W+/, '');
   return str.toLowerCase();

--- a/test.js
+++ b/test.js
@@ -15,6 +15,11 @@ describe('dashify', function () {
     dashify('foo barBaz').should.equal('foo-bar-baz');
     dashify('foo barBaz quux').should.equal('foo-bar-baz-quux');
   });
+  
+  it('should convert space followed by uppercase letter to a single dash:', function() {
+    dashify('foo Bar').should.equal('foo-bar');
+    dashify('Foo BarBaz quux').should.equal('foo-bar-baz-quux');
+  });
 
   it('should convert non-word characters to dashes:', function () {
     dashify('foo*bar').should.equal('foo-bar');


### PR DESCRIPTION
Currently, dashify will convert `'foo Bar'` to `'foo--bar'`.

Changed to output a single dash.

Added test, changed regex, and updated README.